### PR TITLE
Fix Gemini free tier rate limiter

### DIFF
--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -4,8 +4,10 @@ export class FreeTierRateLimiter {
   private dayTimestamps: number[] = [];
 
   constructor(
-    private maxRPM = 30000,
-    private maxTPM = 30000000,
+    // Gemini free tier limits as of June 2024
+    // 60 requests per minute and ~250k tokens per minute
+    private maxRPM = 60,
+    private maxTPM = 250000,
     private maxRPD = 500
   ) {}
 


### PR DESCRIPTION
## Summary
- limit free tier requests to match Gemini quotas

## Testing
- `bun x tsc --noEmit` *(fails: Cannot find type definition file for 'bun-types')*
- `bun install` *(fails: 403 due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685ee85e239083218a57fc6a6bfbbabc